### PR TITLE
Fix typo in gitea-postgres README

### DIFF
--- a/gitea-postgres/README.md
+++ b/gitea-postgres/README.md
@@ -23,7 +23,7 @@ services:
     ...
 ```
 
-When deploying this setup, docker-compose maps the nextcloud container port 3000 to
+When deploying this setup, docker-compose maps the gitea container port 3000 to
 the same port of the host as specified in the compose file.
 
 ## Deploy with docker-compose


### PR DESCRIPTION
In the gitea-postgres README.md a nextcloud container was referenced instead of gitea, most likely it was copied from the nextcloud description.