### PR TITLE
Django - Fixing 'yml' extension

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -4,7 +4,7 @@
 Project structure:
 ```
 .
-├── docker-compose.yaml
+├── docker-compose.yml
 ├── app
     ├── Dockerfile
     ├── requirements.txt
@@ -12,7 +12,7 @@ Project structure:
 
 ```
 
-[_docker-compose.yaml_](docker-compose.yaml)
+[_docker-compose.yml_](docker-compose.yml)
 ```
 services: 
   web: 


### PR DESCRIPTION
Fixing 404 links.
When click on [docker-compose.yaml](https://github.com/docker/awesome-compose/tree/master/django), we get a 404 error.