### PR TITLE
Update React / Spring / MySQL example

### DIFF
--- a/react-java-mysql/README.md
+++ b/react-java-mysql/README.md
@@ -1,5 +1,5 @@
 ## Compose sample application
-### React application with a NodeJS backend and a MySQL database
+### React application with a Spring backend and a MySQL database
 
 Project structure:
 ```

--- a/react-java-mysql/backend/src/main/java/com/company/project/configuration/DockerSecretsProcessor.java
+++ b/react-java-mysql/backend/src/main/java/com/company/project/configuration/DockerSecretsProcessor.java
@@ -1,0 +1,30 @@
+package com.company.project.configuration;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+/**
+ * Read property from docker secret file.
+ */
+public class DockerSecretsProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		Resource resource = new FileSystemResource("/run/secrets/db-password");
+		if (resource.exists() && System.getProperty("MYSQL_PASSWORD") == null) {
+			try {
+				String dbPassword = StreamUtils.copyToString(resource.getInputStream(), Charset.defaultCharset());
+				System.setProperty("MYSQL_PASSWORD", dbPassword);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/react-java-mysql/backend/src/main/resources/META-INF/spring.factories
+++ b/react-java-mysql/backend/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.env.EnvironmentPostProcessor=com.company.project.configuration.DockerSecretsProcessor

--- a/react-java-mysql/docker-compose.yaml
+++ b/react-java-mysql/docker-compose.yaml
@@ -3,6 +3,8 @@ services:
   backend:
     build: backend
     restart: always
+    secrets:
+      - db-password
     environment:
       MYSQL_HOST: db
     networks:

--- a/react-java-mysql/docker-compose.yaml
+++ b/react-java-mysql/docker-compose.yaml
@@ -11,13 +11,19 @@ services:
       - react-spring
       - spring-mysql
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
     environment:
       MYSQL_DATABASE: example
       MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db-password
     image: mysql:8.0.19
     restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--silent"]
+      interval: 3s
+      retries: 5
+      start_period: 30s
     secrets:
       - db-password
     volumes:

--- a/react-java-mysql/docker-compose.yaml
+++ b/react-java-mysql/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3.7"
 services:
   backend:
     build: backend
+    restart: always
     environment:
       MYSQL_HOST: db
     networks:


### PR DESCRIPTION
I would like to suggest the following improvements:
- **Update README.md title from NodeJS to Spring**
- **Always restart spring backend service** -  when starting this example for the first time using `docker-compose up -d` the backend container fails to start as the mysql container is up and running but still initializing and not ready to accept connections. The `depends_on: ...` option doesn't work as expected if the mysql volume isn't initialized yet. By adding `restart: always` the spring backend will restart until the connection to the database can be established. This leads to a lot of exception stacktraces printed to the container log (only when started the first time), but in my opinion thats better than not starting at all.
- **Also pass db-password secret to spring backend** - as the mysql container uses a secret file to set the MYSQL_ROOT_PASSWORD, the spring backend should use the secret file as well, so you can change the `password.txt` file without making any changes to the backend source files.