### PR TITLE
There were two restart in the WordPress docker-compose, delete one of them.

### DIFF
--- a/wordpress-mysql/docker-compose.yaml
+++ b/wordpress-mysql/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   db:
     image: mysql:8.0.19
     command: '--default-authentication-plugin=mysql_native_password'
-    restart: always
     volumes:
       - db_data:/var/lib/mysql
     restart: always


### PR DESCRIPTION
There were two `restart` in the `db` of docker-compose.yml in WordPress, so deleted one of them.