### PR TITLE
Added `--no-cache-dir` option to all Python pip commands in Dockerfiles

### DIFF
--- a/django/app/Dockerfile
+++ b/django/app/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-alpine
 EXPOSE 8000
 WORKDIR /app 
 COPY requirements.txt /app
-RUN pip3 install -r requirements.txt 
+RUN pip3 install -r requirements.txt --no-cache-dir
 COPY . /app 
 ENTRYPOINT ["python3"] 
 CMD ["manage.py", "runserver", "0.0.0.0:8000"]

--- a/flask/app/Dockerfile
+++ b/flask/app/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-alpine 
 WORKDIR /app 
 COPY requirements.txt /app
-RUN pip3 install -r requirements.txt 
+RUN pip3 install -r requirements.txt --no-cache-dir
 COPY . /app 
 ENTRYPOINT ["python3"] 
 CMD ["app.py"]

--- a/nginx-flask-mongo/flask/Dockerfile
+++ b/nginx-flask-mongo/flask/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.7
 
 WORKDIR /src
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["./server.py"]

--- a/nginx-flask-mysql/backend/Dockerfile
+++ b/nginx-flask-mysql/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-alpine
 WORKDIR /code
 COPY requirements.txt /code/
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 COPY . /code/
 ENV FLASK_APP hello.py
 CMD flask run --host=0.0.0.0


### PR DESCRIPTION
The cache gives no benefit to a Docker image but it does add size, hence it's best left out. 

See https://pip.pypa.io/en/stable/reference/pip_install/#caching for relevant pip documentation.