### PR TITLE
Fix Port Type for nginx-flask-mysql

### DIFF
--- a/nginx-flask-mysql/README.md
+++ b/nginx-flask-mysql/README.md
@@ -61,7 +61,7 @@ c2c703b66b19        nginx-flask-mysql_proxy     "nginx -g 'daemon of…"   39 se
 
 After the application starts, navigate to `http://localhost:80` in your web browser or run:
 ```
-$ curl localhost:8080
+$ curl localhost:80
 <div>Blog post #1</div><div>Blog post #2</div><div>Blog post #3</div><div>Blog post #4</div>
 ```
 


### PR DESCRIPTION
There is a tiny localhost port typographical error for "nginx-flask-mysql" in README.

![Screenshot 2021-03-26 at 15 26 52](https://user-images.githubusercontent.com/1482605/112656327-32256380-8e49-11eb-9a23-0b3d1b4f7ee5.png)

Signed-off-by: Wichai Termwuttipreecha <chengings@gmail.com>