### PR TITLE
port 8080 is actually port 80

### DIFF
--- a/nginx-flask-mysql/README.md
+++ b/nginx-flask-mysql/README.md
@@ -28,7 +28,7 @@ services:
     ...
 ```
 The compose file defines an application with three services `proxy`, `backend` and `db`.
-When deploying the application, docker-compose maps port 80 of the proxy service container to port 8080 of the host as specified in the file.
+When deploying the application, docker-compose maps port 80 of the proxy service container to port 80 of the host as specified in the file.
 Make sure port 80 on the host is not already being in use.
 
 ## Deploy with docker-compose
@@ -52,7 +52,7 @@ Listing containers must show three containers running and the port mapping as be
 ```
 $ docker ps
 CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS                    NAMES
-c2c703b66b19        nginx-flask-mysql_proxy     "nginx -g 'daemon of…"   39 seconds ago      Up 38 seconds       0.0.0.0:8080->80/tcp     nginx-flask-mysql_proxy_1
+c2c703b66b19        nginx-flask-mysql_proxy     "nginx -g 'daemon of…"   39 seconds ago      Up 38 seconds       0.0.0.0:80->80/tcp     nginx-flask-mysql_proxy_1
 2b8a21508c3c        nginx-flask-mysql_backend   "/bin/sh -c 'flask r…"   9 minutes ago       Up 38 seconds       0.0.0.0:5000->5000/tcp   nginx-flask-mysql_backend_1
 0e6a96ea2028        mysql:8.0.19                "docker-entrypoint.s…"   9 minutes ago       Up 38 seconds       3306/tcp, 33060/tcp      nginx-flask-mysql_db_1
 
@@ -61,7 +61,7 @@ c2c703b66b19        nginx-flask-mysql_proxy     "nginx -g 'daemon of…"   39 se
 
 After the application starts, navigate to `http://localhost:80` in your web browser or run:
 ```
-$ curl localhost:8080
+$ curl localhost:80
 <div>Blog post #1</div><div>Blog post #2</div><div>Blog post #3</div><div>Blog post #4</div>
 ```
 


### PR DESCRIPTION
Hi,

It seems the port is actually port 80 not 8080 when deploying from default config:

```
# docker ps                                                                                                                                                                        
CONTAINER ID   IMAGE                       COMMAND                  CREATED         STATUS         PORTS                    NAMES
308baa5a6721   nginx-flask-mysql_backend   "/bin/sh -c 'flask r…"   9 minutes ago   Up 9 minutes   0.0.0.0:5000->5000/tcp   nginx-flask-mysql_backend_1
a5755ea6496a   nginx-flask-mysql_proxy     "nginx -g 'daemon of…"   9 minutes ago   Up 9 minutes   0.0.0.0:80->80/tcp       nginx-flask-mysql_proxy_1
1a534b19d81e   mysql:8.0.19                "docker-entrypoint.s…"   9 minutes ago   Up 9 minutes   3306/tcp, 33060/tcp      nginx-flask-mysql_db_1

```