### PR TITLE
Fix typo: `fom` -> `from`

### DIFF
--- a/nginx-flask-mongo/README.md
+++ b/nginx-flask-mongo/README.md
@@ -62,7 +62,7 @@ d7eea5481c77        mongo                       "docker-entrypoint.s…"   About
 After the application starts, navigate to `http://localhost:80` in your web browser or run:
 ```
 $ curl localhost:80
-Hello fom the MongoDB client!
+Hello from the MongoDB client!
 ```
 
 Stop and remove the containers


### PR DESCRIPTION
I fixed typo. The output should be `Hello from the MongoDB client!`.

https://github.com/docker/awesome-compose/blob/744ed86c5598f0ed6bb3454b1f2372c81a7734ac/nginx-flask-mongo/flask/server.py#L17