### PR TITLE
fixed the broken link docker-compose.yaml in README.md of prometheus-…

### DIFF
--- a/prometheus-grafana/README.md
+++ b/prometheus-grafana/README.md
@@ -12,7 +12,7 @@ Project structure:
 └── README.md
 ```
 
-[_docker-compose.yaml_](docker-compose.yaml)
+[_docker-compose.yml_](docker-compose.yml)
 ```
 version: "3.7"
 services:


### PR DESCRIPTION
#136   Fixed the broken link docker-compose.yaml in README.md of prometheus-grafana 

Changed the url from docker-compose.yaml(https://github.com/docker/awesome-compose/blob/master/prometheus-grafana/docker-compose.yaml) to docker-compose.yaml (https://github.com/docker/awesome-compose/blob/master/prometheus-grafana/docker-compose.yml)


Signed-off-by: Dinesh kumar k <dineshkumar12004@gmail.com>