### PR TITLE
fix: set mariadb image to 10.5

### DIFF
--- a/nextcloud-redis-mariadb/docker-compose.yaml
+++ b/nextcloud-redis-mariadb/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
     expose:
       - 6379
   db:
-    image: mariadb
+    image: mariadb:10.5
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: always
     volumes:


### PR DESCRIPTION
The latest tag of the official mariadb image refers to mariadb 10.6, which is not yet officially supported by nextcloud and does not work without modifications.

for more information see:
https://github.com/nextcloud/server/issues/25436#issuecomment-883213001