### PR TITLE
Remove version from compose files to conform to the specification

### DIFF
--- a/angular/README.md
+++ b/angular/README.md
@@ -14,7 +14,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   web:
     build: angular

--- a/angular/docker-compose.yaml
+++ b/angular/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   web:
     build: angular

--- a/apache-php/docker-compose.yaml
+++ b/apache-php/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   web:
     build: app

--- a/aspnet-mssql/docker-compose.yaml
+++ b/aspnet-mssql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   web:
     build: app/aspnetapp

--- a/django/docker-compose.yml
+++ b/django/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3.7' 
-services: 
+services:
   web: 
     build: app 
     ports: 

--- a/elasticsearch-logstash-kibana/docker-compose.yml
+++ b/elasticsearch-logstash-kibana/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   elasticsearch:
     image: elasticsearch:7.8.0

--- a/flask/docker-compose.yaml
+++ b/flask/docker-compose.yaml
@@ -1,5 +1,4 @@
-version: '3' 
-services: 
+services:
   web: 
     build: app 
     ports: 

--- a/gitea-postgres/docker-compose.yaml
+++ b/gitea-postgres/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   gitea:
     image: gitea/gitea:latest

--- a/minecraft/docker-compose.yml
+++ b/minecraft/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
  minecraft:
    image: itzg/minecraft-server

--- a/nextcloud-postgres/docker-compose.yaml
+++ b/nextcloud-postgres/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   nc:
     image: nextcloud:apache

--- a/nextcloud-redis-mariadb/docker-compose.yaml
+++ b/nextcloud-redis-mariadb/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   nc:
     image: nextcloud:apache

--- a/nginx-aspnet-mysql/docker-compose.yaml
+++ b/nginx-aspnet-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build: backend

--- a/nginx-flask-mongo/docker-compose.yaml
+++ b/nginx-flask-mongo/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   web:
     image: nginx

--- a/nginx-flask-mysql/docker-compose.yaml
+++ b/nginx-flask-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   db:
     image: mysql:8.0.19

--- a/nginx-golang-mysql/docker-compose.yaml
+++ b/nginx-golang-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build: backend

--- a/nginx-golang-postgres/docker-compose.yaml
+++ b/nginx-golang-postgres/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build: backend

--- a/nginx-golang/README.md
+++ b/nginx-golang/README.md
@@ -16,7 +16,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   frontend:
     build: frontend

--- a/nginx-golang/docker-compose.yml
+++ b/nginx-golang/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   frontend:
     build: frontend

--- a/nginx-wsgi-flask/docker-compose.yaml
+++ b/nginx-wsgi-flask/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nginx-proxy:
     build: nginx

--- a/prometheus-grafana/README.md
+++ b/prometheus-grafana/README.md
@@ -14,7 +14,6 @@ Project structure:
 
 [_docker-compose.yml_](docker-compose.yml)
 ```
-version: "3.7"
 services:
   prometheus:
     image: prom/prometheus

--- a/prometheus-grafana/docker-compose.yml
+++ b/prometheus-grafana/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   prometheus:
     image: prom/prometheus

--- a/react-express-mongodb/docker-compose.yml
+++ b/react-express-mongodb/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   frontend:
     build: frontend

--- a/react-express-mysql/docker-compose.yaml
+++ b/react-express-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build:

--- a/react-java-mysql/docker-compose.yaml
+++ b/react-java-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build: backend

--- a/react-rust-postgres/docker-compose.yaml
+++ b/react-rust-postgres/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   frontend:
     build:

--- a/sparkjava-mysql/README.md
+++ b/sparkjava-mysql/README.md
@@ -16,7 +16,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   backend:
     build: backend

--- a/sparkjava-mysql/docker-compose.yaml
+++ b/sparkjava-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build: backend

--- a/sparkjava/README.md
+++ b/sparkjava/README.md
@@ -13,7 +13,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   sparkjava:
     build: sparkjava

--- a/sparkjava/docker-compose.yaml
+++ b/sparkjava/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   sparkjava:
     build: sparkjava

--- a/spring-postgres/README.md
+++ b/spring-postgres/README.md
@@ -16,7 +16,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   backend:
     build: backend

--- a/spring-postgres/docker-compose.yaml
+++ b/spring-postgres/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build: backend

--- a/traefik-golang/README.md
+++ b/traefik-golang/README.md
@@ -13,7 +13,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   frontend:
     image: traefik:2.2

--- a/traefik-golang/docker-compose.yml
+++ b/traefik-golang/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   frontend:
     image: traefik:2.2

--- a/vuejs/README.md
+++ b/vuejs/README.md
@@ -13,7 +13,6 @@ Project structure:
 
 [_docker-compose.yaml_](docker-compose.yaml)
 ```
-version: "3.7"
 services:
   web:
     build: vuejs

--- a/vuejs/docker-compose.yaml
+++ b/vuejs/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   web:
     build: vuejs

--- a/wordpress-mysql/docker-compose.yaml
+++ b/wordpress-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   db:
     image: mysql:8.0.19


### PR DESCRIPTION
According to the compose specification, the version is no more needed and its usage is mark as `DEPRECATED`.

https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>