### PR TITLE
remove mongodb unsupported attributes error

### DIFF
--- a/react-express-mongodb/backend/db/index.js
+++ b/react-express-mongodb/backend/db/index.js
@@ -7,11 +7,6 @@ exports.connect = (app) => {
   const options = {
     useNewUrlParser: true,
     autoIndex: false, // Don't build indexes
-    reconnectTries: 30, // Retry up to 30 times
-    reconnectInterval: 500, // Reconnect every 500ms
-    poolSize: 10, // Maintain up to 10 socket connections
-    // If not connected, return errors immediately rather than waiting for reconnect
-    bufferMaxEntries: 0,
   };
 
   const connectWithRetry = () => {


### PR DESCRIPTION
With this attributes running docker-compose crash MongoDB container. I fix it by remove it.
Signed-off-by: Jacek Kałasz <jacek@konsternacja.pl>