### PR TITLE
fixed service name in description

### DIFF
--- a/vuejs/README.md
+++ b/vuejs/README.md
@@ -22,7 +22,7 @@ services:
     - ./vuejs:/project
     - /project/node_modules
 ```
-The compose file defines an application with one service `sparkjava`.
+The compose file defines an application with one service `vuejs`.
 When deploying the application, docker-compose maps port 8080 of the web service container to port 8080 of the host as specified in the file.
 Make sure port 8080 on the host is not already being in use.
 


### PR DESCRIPTION
I assume the README was originally copied from the sparkjava example and whoever copied it forgot to change the service name.