### PR TITLE
Remove temporarily the  'java' codeql analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'java', 'typescript', 'python' ]
+        language: [ 'go', 'typescript', 'python' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
We need to revisit the java code analysis, seems to require a more custom configuration.