### PR TITLE
Use docker hub images and readmes updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ application with Nginx proxy and a Mongo database.
 application with an Nginx proxy and a MySQL database.
 - [`NGINX / Go`](https://github.com/docker/awesome-compose/tree/master/nginx-golang) - Sample Nginx proxy with a Go backend.
 - [`NGINX / WSGI / Flask`](https://github.com/docker/awesome-compose/tree/master/nginx-wsgi-flask) - Sample Nginx reverse proxy with a Flask backend using WSGI.
-- [`Pi-hole / cloudflared`](https://github.com/docker/awesome-compose/tree/master/pihole-cloudflared-DoH) - Sample Pi-hole setup with use of DoH cloudflared service
 - [`PostgreSQL / pgAdmin`](https://github.com/docker/awesome-compose/tree/master/postgresql-pgadmin) - Sample setup for postgreSQL database with pgAdmin web interface
 - [`React / Spring / MySQL`](https://github.com/docker/awesome-compose/tree/master/react-java-mysql) - Sample React
 application with a Spring backend and a MySQL database.
@@ -63,8 +62,9 @@ with Spring framework and a Postgres database.
 - [`Gitea / PostgreSQL`](https://github.com/docker/awesome-compose/tree/master/gitea-postgres)
 - [`Nextcloud / PostgreSQL`](https://github.com/docker/awesome-compose/tree/master/nextcloud-postgres)
 - [`Nextcloud / Redis / MariaDB`](https://github.com/docker/awesome-compose/tree/master/nextcloud-redis-mariadb)
-- [`Wordpress / MySQL`](https://github.com/docker/awesome-compose/tree/master/wordpress-mysql)
+- [`Pi-hole / cloudflared`](https://github.com/docker/awesome-compose/tree/master/pihole-cloudflared-DoH) - Sample Pi-hole setup with use of DoH cloudflared service
 - [`Prometheus / Grafana`](https://github.com/docker/awesome-compose/tree/master/prometheus-grafana)
+- [`Wordpress / MySQL`](https://github.com/docker/awesome-compose/tree/master/wordpress-mysql)
 
 <!--lint disable awesome-toc-->
 ## Getting started

--- a/plex/README.md
+++ b/plex/README.md
@@ -43,7 +43,7 @@ Check containers are running:
 ```
 $ docker ps
 CONTAINER ID   IMAGE                             COMMAND                  CREATED          STATUS         PORTS                                          NAMES
-62fc3ff1f1a0   ghcr.io/linuxserver/plex:latest   "/init"                  38 seconds ago   Up 3 seconds                                                  plex
+62fc3ff1f1a0   linuxserver/plex:latest           "/init"                  38 seconds ago   Up 3 seconds                                                  plex
 ```
 
 Navigate to `http://localhost:32400/web` in your web browser to access the plex web interface.

--- a/plex/docker-compose.yaml
+++ b/plex/docker-compose.yaml
@@ -1,7 +1,6 @@
-version: '3.7'
 services:
   plex:
-    image: ghcr.io/linuxserver/plex:latest
+    image: linuxserver/plex
     container_name: plex
     network_mode: host
     environment:

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   portainer:
     image: portainer/portainer-ce:alpine

--- a/postgresql-pgadmin/docker-compose.yaml
+++ b/postgresql-pgadmin/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   postgres:
     container_name: postgres

--- a/wireguard/README.md
+++ b/wireguard/README.md
@@ -14,7 +14,7 @@ Project structure:
 ``` yaml
 services:
   wireguard:
-    image: ghcr.io/linuxserver/wireguard
+    image: linuxserver/wireguard
 ```
 
 ## Configuration
@@ -46,7 +46,7 @@ Check containers are running:
 ```
 $ docker ps
 CONTAINER ID   IMAGE                           COMMAND                  CREATED          STATUS                          PORTS                                                                                  NAMES
-4992922d23dc   ghcr.io/linuxserver/wireguard   "/init"                  7 seconds ago    Up 5 seconds                    0.0.0.0:51820->51820/udp, :::51820->51820/udp                                          wireguard
+4992922d23dc   linuxserver/wireguard           "/init"                  7 seconds ago    Up 5 seconds                    0.0.0.0:51820->51820/udp, :::51820->51820/udp                                          wireguard
 ```
 
 ## Mobile Wireguard App

--- a/wireguard/docker-compose.yaml
+++ b/wireguard/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   wireguard:
-    image: ghcr.io/linuxserver/wireguard
+    image: linuxserver/wireguard
     container_name: wireguard
     cap_add:
       - NET_ADMIN


### PR DESCRIPTION
Remove version fields as they are not needed.
Use images from Docker Hub for consistency with other examples.