### PR TITLE
fixed ImportError

### DIFF
--- a/nginx-flask-mysql/backend/requirements.txt
+++ b/nginx-flask-mysql/backend/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.1.1
+Flask==2.0.1
 mysql-connector==2.2.9


### PR DESCRIPTION
fixed ImportError: cannot import name 'json' from 'itsdangerous'  for nginx-flask-mysql by upgrading flask to version 2.0.1
Signed-off-by: Shereef Bankole <shereef.bankole@yahoo.com>