### PR TITLE
fix: update traefik minor version to v2.6

### DIFF
--- a/traefik-golang/README.md
+++ b/traefik-golang/README.md
@@ -15,7 +15,7 @@ Project structure:
 ```
 services:
   frontend:
-    image: traefik:2.2
+    image: traefik:2.6
     command: --providers.docker --entrypoints.web.address=:80 --providers.docker.exposedbydefault=false
     ports:
       # The HTTP port
@@ -49,14 +49,14 @@ Step 1/7 : FROM golang:1.13 AS build
 Successfully built 22397f6cd4bc
 Successfully tagged traefik-golang_backend:latest
 WARNING: Image for service backend was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
-Pulling frontend (traefik:2.2)...
-2.2: Pulling from library/traefik
-aad63a933944: Pull complete
-f365f1b91ebb: Pull complete
-dc367a6045f5: Pull complete
-ff697159d003: Pull complete
-Digest: sha256:615483752426932469aa2229ef3f0825b33b3ad7e1326dcd388205cb3a74352e
-Status: Downloaded newer image for traefik:2.2
+Pulling frontend (traefik:2.6)...
+2.6: Pulling from library/traefik
+8663204ce13b: Pull complete
+1a6b5dadc224: Pull complete
+c7891231da41: Pull complete
+9e3c91eff4e8: Pull complete
+Digest: sha256:9dc508fe4f1516b81ec97ed37dd4f3b406f02eda72c7c0dcd9f74d23fbc82239
+Status: Downloaded newer image for traefik:2.6
 Creating traefik-golang_backend_1 ... done
 Creating traefik-golang_frontend_1 ... done
 ```
@@ -66,11 +66,9 @@ Creating traefik-golang_frontend_1 ... done
 Listing containers must show two containers running and the port mapping as below:
 ```
 $ docker ps
-CONTAINER ID        IMAGE                    COMMAND                  CREATED             STATUS              PORTS  
-              NAMES
-e845f50da9e6        traefik:2.2              "/entrypoint.sh --pr…"   55 seconds ago      Up 54 seconds       0.0.0.0:80->80/tcp   traefik-golang_frontend_1
-e164ffd692e8        traefik-golang_backend   "/usr/local/bin/back…"   55 seconds ago      Up 54 seconds
-              traefik-golang_backend_1
+CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS                               NAMES
+e0a0f3191042   traefik:2.6              "/entrypoint.sh --pr…"   42 seconds ago   Up 42 seconds   0.0.0.0:80->80/tcp, :::80->80/tcp   traefik-golang-frontend-1
+662d1506f1fd   traefik-golang_backend   "/usr/local/bin/back…"   42 seconds ago   Up 42 seconds                                       traefik-golang-backend-1
 ```
 
 After the application starts, navigate to `http://localhost:80` in your web browser or run:
@@ -86,7 +84,7 @@ $ curl localhost:80
  \    \         __/
   \____\_______/
 
-	
+
 Hello from Docker!
 ```
 

--- a/traefik-golang/compose.yaml
+++ b/traefik-golang/compose.yaml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: traefik:2.2
+    image: traefik:2.6
     command: --providers.docker --entrypoints.web.address=:80 --providers.docker.exposedbydefault=false
     ports:
       # The HTTP port


### PR DESCRIPTION
This PR updates traefik version from v2.2 to v2.6.

https://github.com/traefik/traefik/compare/v2.2...v2.6