### PR TITLE
update java samples to use eclipse temurin instead of opendjdk

### DIFF
--- a/react-java-mysql/backend/Dockerfile
+++ b/react-java-mysql/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11 AS builder
+FROM --platform=$BUILDPLATFORM maven:3.8.5-eclipse-temurin-17 AS builder
 WORKDIR /workdir/server
 COPY pom.xml /workdir/server/pom.xml
 RUN mvn dependency:go-offline
@@ -9,7 +9,7 @@ RUN mkdir -p target/dependency
 WORKDIR /workdir/server/target/dependency
 RUN jar -xf ../*.jar
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre-focal
 
 EXPOSE 8080
 VOLUME /tmp

--- a/sparkjava-mysql/backend/Dockerfile
+++ b/sparkjava-mysql/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.8.5-eclipse-temurin-17 AS build
 WORKDIR /workdir/server
 COPY pom.xml /workdir/server/pom.xml
 RUN mvn dependency:go-offline
@@ -7,7 +7,7 @@ COPY src /workdir/server/src
 
 RUN mvn --batch-mode clean compile assembly:single
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre-focal
 ARG DEPENDENCY=/workdir/server/target
 EXPOSE 8080
 COPY --from=build ${DEPENDENCY}/app.jar /app.jar

--- a/sparkjava/sparkjava/Dockerfile
+++ b/sparkjava/sparkjava/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.8.5-eclipse-temurin-17 AS build
 WORKDIR /workdir/server
 COPY pom.xml /workdir/server/pom.xml
 RUN mvn dependency:go-offline
@@ -7,7 +7,7 @@ COPY src /workdir/server/src
 
 RUN mvn --batch-mode clean compile assembly:single
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre-focal
 ARG DEPENDENCY=/workdir/server/target
 EXPOSE 8080
 COPY --from=build ${DEPENDENCY}/app.jar /app.jar

--- a/spring-postgres/backend/Dockerfile
+++ b/spring-postgres/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11 AS builder
+FROM --platform=$BUILDPLATFORM maven:3.8.5-eclipse-temurin-17 AS builder
 WORKDIR /workdir/server
 COPY pom.xml /workdir/server/pom.xml
 RUN mvn dependency:go-offline
@@ -9,7 +9,7 @@ RUN mkdir  -p target/depency
 WORKDIR /workdir/server/target/dependency
 RUN jar -xf ../*.jar
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre-focal
 
 EXPOSE 8080
 VOLUME /tmp


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>