### PR TITLE
add configuration to use sparkjave-mysql sample with Docker Dev Environments feature

### DIFF
--- a/sparkjava-mysql/.docker/docker-compose.yaml
+++ b/sparkjava-mysql/.docker/docker-compose.yaml
@@ -1,0 +1,32 @@
+services:
+  backend:
+    build:
+      context: backend
+      target: dev-envs
+    ports:
+      - 8080:8080
+    secrets:
+      - db-password
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  db:
+    # We use a mariadb image which supports both amd64 & arm64 architecture
+    image: mariadb:10.6.4-focal
+    # If you really want to use MySQL, uncomment the following line
+    #image: mysql:8.0.27
+    restart: always
+    secrets:
+      - db-password
+    volumes:
+      - db-data:/var/lib/mysql
+    environment:
+      - MYSQL_DATABASE=example
+      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/db-password
+    expose:
+      - 3306
+      - 33060   
+volumes:
+  db-data:
+secrets:
+  db-password:
+    file: db/password.txt

--- a/sparkjava-mysql/README.md
+++ b/sparkjava-mysql/README.md
@@ -75,3 +75,11 @@ Removing sparkjava-mysql_backend_1 ... done
 Removing sparkjava-mysql_db_1      ... done
 Removing network sparkjava-mysql_default
 ```
+
+## Use with Docker Development Environments
+
+You can use this sample with the Dev Environments feature of Docker Desktop.  
+To develop directly frontend or the backend services inside containers, you just need to use the https git url of the sample:  
+`https://github.com/docker/awesome-compose/tree/master/sparkjava-mysql`
+
+![page](../dev-envs.png)

--- a/sparkjava-mysql/backend/Dockerfile
+++ b/sparkjava-mysql/backend/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM --platform=$BUILDPLATFORM maven:3.8.5-eclipse-temurin-17 AS build
 WORKDIR /workdir/server
 COPY pom.xml /workdir/server/pom.xml
@@ -6,6 +8,21 @@ RUN mvn dependency:go-offline
 COPY src /workdir/server/src
 
 RUN mvn --batch-mode clean compile assembly:single
+
+FROM build AS dev-envs
+RUN <<EOF
+apt-get update
+apt-get install -y --no-install-recommends git
+EOF
+
+RUN <<EOF
+useradd -s /bin/bash -m vscode
+groupadd docker
+usermod -aG docker vscode
+EOF
+# install Docker tools (cli, buildx, compose)
+COPY --from=gloursdocker/docker / /
+CMD ["java", "-jar", "target/app.jar" ]
 
 FROM eclipse-temurin:17-jre-focal
 ARG DEPENDENCY=/workdir/server/target


### PR DESCRIPTION
- Add a dedicated Compose file in the .docker directory for Dev Env configuration
- Add a new dev-envs stage in backend Dockerfile
- Update documentation