### PR TITLE
angular: fix readme for dev envs

### DIFF
--- a/angular/README.md
+++ b/angular/README.md
@@ -65,3 +65,14 @@ Stop and remove the container
 ```
 $ docker compose down
 ```
+
+## Use with Docker Development Environments
+
+You can use this sample with the Dev Environments feature of Docker Desktop.
+
+![Screenshot of creating a Dev Environment in Docker Desktop](../dev-envs.png)
+
+To develop directly on the services inside containers, use the HTTPS Git url of the sample:
+```
+https://github.com/docker/awesome-compose/tree/master/angular
+```

--- a/angular/angular/README.md
+++ b/angular/angular/README.md
@@ -4,17 +4,24 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `docker compose up -d` for a dev server.
-Navigate to `http://localhost:4200/`.
-The app will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
-## Use with Docker Development Environments
+## Code scaffolding
 
-You can use this sample with the Dev Environments feature of Docker Desktop.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
 
-![Screenshot of creating a Dev Environment in Docker Desktop](../dev-envs.png)
+## Build
 
-To develop directly on the services inside containers, use the HTTPS Git url of the sample:
-```
-https://github.com/docker/awesome-compose/tree/master/angular
-```
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+## Running unit tests
+
+Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+
+## Running end-to-end tests
+
+Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+
+## Further help
+
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.


### PR DESCRIPTION
I accidentally edited the wrong `README`, which was the inner one
from the app generated by Angular CLI rather than the project
one about Compose.

Restored the old one and moved the dev envs info to the root/Compose
README.

See #255.