### PR TITLE
add configuration to use sparkjava sample with Docker Dev Environments feature

### DIFF
--- a/sparkjava/.docker/docker-compose.yaml
+++ b/sparkjava/.docker/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  sparkjava:
+    build:
+      context: sparkjava
+      target: dev-envs
+    ports:
+      - 8080:8080
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/sparkjava/README.md
+++ b/sparkjava/README.md
@@ -59,3 +59,11 @@ Stopping sparkjava_sparkjava_1 ... done
 Removing sparkjava_sparkjava_1 ... done
 Removing network sparkjava_default
 ```
+
+## Use with Docker Development Environments
+
+You can use this sample with the Dev Environments feature of Docker Desktop.  
+To develop directly sparkjava service inside containers, you just need to use the https git url of the sample:  
+`https://github.com/docker/awesome-compose/tree/master/sparkjava`
+
+![page](../dev-envs.png)

--- a/sparkjava/sparkjava/Dockerfile
+++ b/sparkjava/sparkjava/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM --platform=$BUILDPLATFORM maven:3.8.5-eclipse-temurin-17 AS build
 WORKDIR /workdir/server
 COPY pom.xml /workdir/server/pom.xml
@@ -6,6 +8,21 @@ RUN mvn dependency:go-offline
 COPY src /workdir/server/src
 
 RUN mvn --batch-mode clean compile assembly:single
+
+FROM build AS dev-envs
+RUN <<EOF
+apt-get update
+apt-get install -y --no-install-recommends git
+EOF
+
+RUN <<EOF
+useradd -s /bin/bash -m vscode
+groupadd docker
+usermod -aG docker vscode
+EOF
+# install Docker tools (cli, buildx, compose)
+COPY --from=gloursdocker/docker / /
+CMD ["java", "-jar", "target/app.jar" ]
 
 FROM eclipse-temurin:17-jre-focal
 ARG DEPENDENCY=/workdir/server/target


### PR DESCRIPTION
- Add a dedicated Compose file in the .docker directory for Dev Env configuration
- Add a new dev-envs stage in sparkjava Dockerfile
- Update documentation