### PR TITLE
flask-redis: dev envs support & misc improvements

### DIFF
--- a/flask-redis/.docker/docker-compose.yaml
+++ b/flask-redis/.docker/docker-compose.yaml
@@ -6,13 +6,11 @@ services:
   web:
     build:
       context: .
-      target: builder
-    # flask requires SIGINT to stop gracefully
-    # (default stop signal from Compose is SIGTERM)
+      target: dev-envs
     stop_signal: SIGINT
     ports:
       - '8000:8000'
     volumes:
-      - .:/code
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - redis

--- a/flask-redis/Dockerfile
+++ b/flask-redis/Dockerfile
@@ -1,6 +1,27 @@
-FROM python:3.11.0a6-alpine3.15
+# syntax=docker/dockerfile:1.4
+FROM --platform=$BUILDPLATFORM python:3.10-alpine AS builder
+
 WORKDIR /code
+
 COPY requirements.txt /code
-RUN pip install -r requirements.txt --no-cache-dir
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install -r requirements.txt
+
 COPY . /code
-CMD python app.py
+
+ENTRYPOINT ["python3"]
+CMD ["app.py"]
+
+FROM builder as dev-envs
+
+RUN <<EOF
+apk update
+apk add git bash
+EOF
+
+RUN <<EOF
+addgroup -S docker
+adduser -S --shell /bin/bash --ingroup docker vscode
+EOF
+# install Docker tools (cli, buildx, compose)
+COPY --from=gloursdocker/docker / /

--- a/flask-redis/README.md
+++ b/flask-redis/README.md
@@ -24,7 +24,7 @@ services:
    web:
         build: .
         ports:
-            - "5000:5000"
+            - "8000:8000"
         volumes:
             - .:/code
         depends_on:
@@ -55,12 +55,12 @@ Listing containers must show one container running and the port mapping as below
 $ docker compose ps
 NAME                  COMMAND                  SERVICE             STATUS              PORTS
 flask-redis-redis-1   "redis-server --load…"   redis               running             0.0.0.0:6379->6379/tcp
-flask-redis-web-1     "/bin/sh -c 'python …"   web                 running             0.0.0.0:5000->5000/tcp
+flask-redis-web-1     "/bin/sh -c 'python …"   web                 running             0.0.0.0:8000->8000/tcp
 ```
 
-After the application starts, navigate to `http://localhost:5000` in your web browser or run:
+After the application starts, navigate to `http://localhost:8000` in your web browser or run:
 ```
-$ curl localhost:5000
+$ curl localhost:8000
 This webpage has been viewed 2 time(s)
 ```
 
@@ -79,4 +79,15 @@ OK
 Stop and remove the containers
 ```
 $ docker compose down
+```
+
+## Use with Docker Development Environments
+
+You can use this sample with the Dev Environments feature of Docker Desktop.
+
+![Screenshot of creating a Dev Environment in Docker Desktop](../dev-envs.png)
+
+To develop directly on the services inside containers, use the HTTPS Git url of the sample:
+```
+https://github.com/docker/awesome-compose/tree/master/flask-redis
 ```

--- a/flask-redis/app.py
+++ b/flask-redis/app.py
@@ -11,4 +11,4 @@ def hello():
     return "This webpage has been viewed "+counter+" time(s)"
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", debug=True)
+    app.run(host="0.0.0.0", port=8000, debug=True)


### PR DESCRIPTION
(Most of this is almost identical to #263.)

* Docker Desktop Development Environments config
* Use cache volumes for pip
* Downgrade from Python 3.11 _alpha_ -> Python 3.10
* Use port `8000` to avoid conflicts with Airplay on
    macOS for default Flask port `5000`
* Use `SIGINT` to gracefully stop Flask
* Formatting fixes in `compose.yaml`