### PR TITLE
Remove container_name to allow multiple apps in parallel

### DIFF
--- a/react-express-mongodb/.docker/docker-compose.yaml
+++ b/react-express-mongodb/.docker/docker-compose.yaml
@@ -29,7 +29,6 @@ services:
     expose: 
       - 3000
   mongo:
-    container_name: mongo
     restart: always
     image: mongo:4.2.0
     volumes:

--- a/react-express-mongodb/compose.yaml
+++ b/react-express-mongodb/compose.yaml
@@ -9,7 +9,6 @@ services:
     volumes:
       - ./frontend:/usr/src/app
       - /usr/src/app/node_modules
-    container_name: frontend
     restart: always
     networks:
       - react-express
@@ -17,7 +16,6 @@ services:
       - backend
 
   backend:
-    container_name: backend
     restart: always
     build:
       context: backend
@@ -33,7 +31,6 @@ services:
     expose: 
       - 3000
   mongo:
-    container_name: mongo
     restart: always
     image: mongo:4.2.0
     volumes:


### PR DESCRIPTION
During a test I wanted to create a second dev environment for the react-express-mongo example, but it failed, because the container name "mongo" is already in use by a stopped other dev env.

<img width="1920" alt="Screenshot 2022-11-23 at 11 33 05" src="https://user-images.githubusercontent.com/207759/203528799-1cf57f1a-cd4d-4354-85f1-52e783a1946d.png">

I suggest to remove the `container_name` from the Docker Compose file, because Compose automatically assigns the service name and service lookup via host names work fine. The whole app still works fine.
