### PR TITLE
Update requirements.txt

### DIFF
--- a/nginx-flask-mysql/backend/requirements.txt
+++ b/nginx-flask-mysql/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
+Werkzeug==2.2.2
 mysql-connector==2.2.9


### PR DESCRIPTION
Fix nginx-flask-mysql-backend-1  | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/site-packages/werkzeug/urls.py) By specifying the correct requirement.