### PR TITLE
align nginx-nodejs-redis README content with compose.yaml file

### DIFF
--- a/nginx-nodejs-redis/README.md
+++ b/nginx-nodejs-redis/README.md
@@ -21,7 +21,8 @@ Project structure:
 ```
 [_compose.yaml_](compose.yaml)
 ```
-redis:
+services:
+  redis:
     image: 'redislabs/redismod'
     ports:
       - '6379:6379'
@@ -40,10 +41,10 @@ redis:
   nginx:
     build: ./nginx
     ports:
-    - '80:80'
+      - '80:80'
     depends_on:
-    - web1
-    - web2
+      - web1
+      - web2
 ```
 The compose file defines an application with four services `redis`, `nginx`, `web1` and `web2`.
 When deploying the application, docker compose maps port 80 of the nginx service container to port 80 of the host as specified in the file.


### PR DESCRIPTION
Copying and pasting from the README file directly gives you a "BAD_INDENT" error. This PR updates the content in the README to match what is inside the compose.yaml file the README is referencing.