### PR TITLE
nginx-flask-mysql: Add Werkzeug's version

### DIFF
--- a/nginx-flask-mysql/backend/requirements.txt
+++ b/nginx-flask-mysql/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
 mysql-connector==2.2.9
+Werkzeug==2.2.2


### PR DESCRIPTION
Specified Werkzeug's version as 2.2.2 in "requirements.txt"

Reference: https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr