### PR TITLE
Update requirements.txt

### DIFF
--- a/nginx-flask-mysql/backend/requirements.txt
+++ b/nginx-flask-mysql/backend/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.0.1
-mysql-connector==2.2.9
+Werkzeug==2.3.7
+Flask==2.2.2


### PR DESCRIPTION
Specifying those versions will prevent the following error (caused by compability issues) :

```shell
nginx-flask-mysql-backend-1  | Traceback (most recent call last):
nginx-flask-mysql-backend-1  |   File "/usr/local/bin/flask", line 5, in <module>
nginx-flask-mysql-backend-1  |     from flask.cli import main
nginx-flask-mysql-backend-1  |   File "/usr/local/lib/python3.10/site-packages/flask/__init__.py", line 7, in <module>
nginx-flask-mysql-backend-1  |     from .app import Flask as Flask
nginx-flask-mysql-backend-1  |   File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 28, in <module>
nginx-flask-mysql-backend-1  |     from . import cli
nginx-flask-mysql-backend-1  |   File "/usr/local/lib/python3.10/site-packages/flask/cli.py", line 18, in <module>
nginx-flask-mysql-backend-1  |     from .helpers import get_debug_flag
nginx-flask-mysql-backend-1  |   File "/usr/local/lib/python3.10/site-packages/flask/helpers.py", line 16, in <module>
nginx-flask-mysql-backend-1  |     from werkzeug.urls import url_quote
nginx-flask-mysql-backend-1  | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/site-packages/werkzeug/urls.py)
nginx-flask-mysql-backend-1 exited with code 1
```