### PR TITLE
Add Werkzeug version for Flask compatibility

### DIFF
--- a/nginx-flask-mysql/backend/requirements.txt
+++ b/nginx-flask-mysql/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
+Werkzeug==2.3.8
 mysql-connector==2.2.9


### PR DESCRIPTION
### Notes
Without specification, encountered:
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' 
```
More info: https://stackoverflow.com/a/77214086/25767187

### Testing
Ran `docker compose up --build` successfully with app running and no errors