### PR TITLE
Fix letter case of the word 'as' in Dockerfile for consistency

### DIFF
--- a/react-express-mysql/frontend/Dockerfile
+++ b/react-express-mysql/frontend/Dockerfile
@@ -17,7 +17,7 @@ FROM development AS builder
 
 RUN npm run build
 
-FROM development as dev-envs
+FROM development AS dev-envs
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends git


### PR DESCRIPTION
The FROM ... AS command in the modified Dockerfile has consistently user uppercase in all instances except on line 20. I updated the letter case of the word 'as' for consistency.

Signed-off-by: Paul Merupu <paulmerupu91@gmail.com>