### PR TITLE
Alertmanager API version fix(prometheus 3)

### DIFF
--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
     - targets: []
     scheme: http
     timeout: 10s
-    api_version: v1
+    api_version: v2
 scrape_configs:
 - job_name: prometheus
   honor_timestamps: true


### PR DESCRIPTION
I got an error with that installation:

time=2024-11-17T05:52:03.562Z level=ERROR source=main.go:601 msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" file=/etc/prometheus/prometheus.yml err="parsing YAML file /etc/prometheus/prometheus.yml: expected Alertmanager api version to be one of [v2] but got v1"


Fixed by change of alertmanager api to v2.