### PR TITLE
Remove dev environments build steps from Django example

### DIFF
--- a/django/app/Dockerfile
+++ b/django/app/Dockerfile
@@ -1,24 +1,10 @@
 # syntax=docker/dockerfile:1.4
 
-FROM --platform=$BUILDPLATFORM python:3.7-alpine AS builder
+FROM python:3.7-alpine
 EXPOSE 8000
 WORKDIR /app 
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt --no-cache-dir
 COPY . /app 
 ENTRYPOINT ["python3"] 
-CMD ["manage.py", "runserver", "0.0.0.0:8000"]
-
-FROM builder as dev-envs
-RUN <<EOF
-apk update
-apk add git
-EOF
-
-RUN <<EOF
-addgroup -S docker
-adduser -S --shell /bin/bash --ingroup docker vscode
-EOF
-# install Docker tools (cli, buildx, compose)
-COPY --from=gloursdocker/docker / /
 CMD ["manage.py", "runserver", "0.0.0.0:8000"]

--- a/django/compose.yaml
+++ b/django/compose.yaml
@@ -1,7 +1,5 @@
 services:
   web: 
-    build:
-      context: app
-      target: builder
+    build: app
     ports: 
       - '8000:8000'


### PR DESCRIPTION
Issue #401

https://github.com/docker/awesome-compose/issues/401#issuecomment-2425243369
> [...] many of the examples in this repo were previously updated to support Docker's dev environment feature, which required additional support and tooling inside of the image. Since then, dev environments have been deprecated and the Compsoe-based configuration was removed. But, it appears the Dockerfiles were not updated.

Reverts #252