### PR TITLE
Add django-insecure prefix to hardcoded secret key

### DIFF
--- a/django/app/example/settings.py
+++ b/django/app/example/settings.py
@@ -29,7 +29,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env('SECRET_KEY',
-                'h8+mu_iy6%5j%7+hp**+gsq$nmy!!mjd8z_qkd94@z!%9%!+qn')
+                'django-insecure-h8+mu_iy6%5j%7+hp**+gsq$nmy!!mjd8z_qkd94@z!%9%!+qn')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool('DEBUG', True)


### PR DESCRIPTION
Not ideal that this is hardcoded into the example project, but this (Django standard) prefix will at least add a warning if the user runs [`./manage.py check --deploy`](https://docs.djangoproject.com/en/5.1/ref/checks/#security).