### PR TITLE
fix: Add depends_on statement

### DIFF
--- a/wordpress-mysql/compose.yaml
+++ b/wordpress-mysql/compose.yaml
@@ -26,6 +26,8 @@ services:
       - WORDPRESS_DB_USER=wordpress
       - WORDPRESS_DB_PASSWORD=wordpress
       - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      - db
 volumes:
   db_data:
 


### PR DESCRIPTION
While I tried this docker compose file, the wordpress service couldn't start because of the delayed start of the db service. So I manged to add the depends_on to wait for the db service.