### PR TITLE
Update prometheus.yml to api_version: v2

### DIFF
--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
     - targets: []
     scheme: http
     timeout: 10s
-    api_version: v1
+    api_version: v2
 scrape_configs:
 - job_name: prometheus
   honor_timestamps: true


### PR DESCRIPTION
Resolved error at runtime expecting v2 but getting v1:

`level=ERROR source=main.go:593 msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" file=/etc/prometheus/prometheus.yml err="parsing YAML file /etc/prometheus/prometheus.yml: expected Alertmanager api version to be one of [v2] but got v1"`