### PR TITLE
Fix typo in ASP.NET sample description

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with an Nginx proxy and a MySQL database.
 application with an Nginx proxy and a PostgreSQL database.
 - [`Java Spark / MySQL`](sparkjava-mysql) - Sample Java application and
 a MySQL database.
-- [`NGINX / ASP.NET / MySQL`](nginx-aspnet-mysql) - Sample Nginx reverse proxy with an C# backend using ASP.NET.
+- [`NGINX / ASP.NET / MySQL`](nginx-aspnet-mysql) - Sample Nginx reverse proxy with a C# backend using ASP.NET.
 - [`NGINX / Flask / MongoDB`](nginx-flask-mongo) - Sample Python/Flask
 application with Nginx proxy and a Mongo database.
 - [`NGINX / Flask / MySQL`](nginx-flask-mysql) - Sample Python/Flask application with an Nginx proxy and a MySQL database.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ a local environment by going into the root directory of each one and executing:
 ```console
 docker compose up -d
 ```
-
+Run `docker compose ps` to verify services are up.
 Check the `README.md` of each sample to get more details on the structure and
 what is the expected output.
 To stop and remove all containers of the sample application run:


### PR DESCRIPTION
Changed ‘an C# backend’ to ‘a C# backend’ for correct grammar.