### PR TITLE
:gear:  Update prometheus alert manager api version

### DIFF
--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
     - targets: []
     scheme: http
     timeout: 10s
-    api_version: v2
+    api_version: v1
 scrape_configs:
 - job_name: prometheus
   honor_timestamps: true

--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
     - targets: []
     scheme: http
     timeout: 10s
-    api_version: v1
+    api_version: v2
 scrape_configs:
 - job_name: prometheus
   honor_timestamps: true


### PR DESCRIPTION
**Fix: update Alertmanager API version to v2 in prometheus.yml**

Changed `api_version` from `v1` to `v2` in `prometheus.yml` to resolve  
configuration error: "expected Alertmanager API version to be one of [v2] but got v1".
