### PR TITLE
:gear: fix: update Alertmanager API version to v2 in prometheus.yml

### DIFF
--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
     - targets: []
     scheme: http
     timeout: 10s
-    api_version: v1
+    api_version: v2
 scrape_configs:
 - job_name: prometheus
   honor_timestamps: true


### PR DESCRIPTION
**Fix: update Alertmanager API version to v2 in prometheus.yml**

Updated the `api_version` field in `prometheus.yml` from `v1` to `v2` to resolve  a configuration issue that caused Prometheus to fail with the error:  

`"expected Alertmanager API version to be one of [v2] but got v1". `

This change ensures compatibility with the latest Alertmanager version, allowing Prometheus to correctly integrate and process alerts as expected.
