### PR TITLE
fix: remove invalid expose from frontend service

### DIFF
--- a/react-java-mysql/compose.yaml
+++ b/react-java-mysql/compose.yaml
@@ -32,6 +32,9 @@ services:
       - db-data:/var/lib/mysql
     networks:
       - spring-mysql
+    expose:
+      - 3306
+      - 33060
   frontend:
     build:
       context: frontend
@@ -45,9 +48,6 @@ services:
       - react-spring
     depends_on:
       - backend
-    expose:
-      - 3306
-      - 33060
 volumes:
   db-data: {}
 secrets:


### PR DESCRIPTION
The frontend service incorrectly exposed MySQL port 3306, which is not required since it doesn't run any database. This commit removes the unnecessary expose  directive and ensures that only the db service exposes the appropriate ports.