### PR TITLE
Add Go + Redis Docker Compose sample

### DIFF
--- a/go-redis/README.md
+++ b/go-redis/README.md
@@ -1,0 +1,132 @@
+## Compose sample application
+### Go + Redis
+
+This sample demonstrates how to run a simple Go HTTP application backed by a
+Redis datastore using Docker Compose.
+
+The Go application exposes a basic HTTP endpoint. Each request increments a
+counter value stored in Redis and returns the updated count.
+
+---
+
+## Project structure
+
+```
+
+.
+├── app
+│   ├── Dockerfile
+│   ├── main.go
+│   ├── go.mod
+│   └── go.sum
+├── compose.yaml
+└── README.md
+
+````
+
+---
+
+## Services
+
+- **app**: Go HTTP server that handles incoming requests and communicates with Redis
+- **redis**: Redis key-value store used to persist the counter value
+
+---
+
+## Compose file
+
+[_compose.yaml_](compose.yaml)
+
+```yaml
+services:
+  app:
+    build: app
+    ports:
+      - 8080:8080
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+````
+
+### Explanation
+
+* The `app` service builds a Docker image from the `app` directory.
+* The Go application listens on port `8080` inside the container.
+* Port `8080` of the container is mapped to port `8080` on the host.
+* The `redis` service runs an official Redis image.
+* The Go application connects to Redis using the service name `redis` as the hostname.
+
+---
+
+### Optional: Clean Go modules
+
+Before building, you can run inside `app`:
+
+```bash
+cd app
+go mod tidy
+
+
+## Deploy with docker compose
+
+From the project directory, run:
+
+```console
+$ docker compose up -d
+```
+
+Docker Compose will:
+
+* Build the Go application image
+* Start the Redis container
+* Start the Go HTTP server
+
+---
+
+## Expected result
+
+Listing containers must show two containers running:
+
+```console
+$ docker compose ps
+```
+
+Example output:
+
+```
+NAME                   SERVICE   STATUS    PORTS
+go-redis-app-1         app       running   0.0.0.0:8080->8080/tcp
+go-redis-redis-1       redis     running
+```
+
+---
+
+## Access the application
+
+Open your browser or run:
+
+```console
+$ curl http://localhost:8080/count
+```
+
+Each request increments a counter stored in Redis and returns a response similar
+to the following:
+
+```
+count : 1
+```
+
+---
+
+## Stop the application
+
+To stop and remove the containers and network, run:
+
+```console
+$ docker compose down
+```
+
+---
+

--- a/go-redis/app/Dockerfile
+++ b/go-redis/app/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o app
+
+
+FROM alpine:3.19
+
+WORKDIR /app
+
+COPY --from=builder /app/app .
+
+EXPOSE 8080
+
+CMD ["./app"]

--- a/go-redis/app/go.mod
+++ b/go-redis/app/go.mod
@@ -1,0 +1,10 @@
+module go-redis-example
+
+go 1.21
+
+require github.com/redis/go-redis/v9 v9.3.0
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/go-redis/app/go.sum
+++ b/go-redis/app/go.sum
@@ -1,0 +1,10 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/redis/go-redis/v9 v9.3.0 h1:RiVDjmig62jIWp7Kk4XVLs0hzV6pI3PyTnnL0cnn0u0=
+github.com/redis/go-redis/v9 v9.3.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=

--- a/go-redis/app/main.go
+++ b/go-redis/app/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var ctx = context.Background()
+
+func main() {
+	redisAddr := os.Getenv("REDIS_ADDR")
+	if redisAddr == "" {
+		redisAddr = "redis:6379"
+	}
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr: redisAddr,
+	})
+
+	http.HandleFunc("/count", func(w http.ResponseWriter, r *http.Request) {
+		count, err := rdb.Incr(ctx, "counter").Result()
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		fmt.Fprintf(w, `{"count": %d}`, count)
+	})
+
+	log.Println("Server started on port :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go-redis/compose.yaml
+++ b/go-redis/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  app:
+    build: ./app
+    ports:
+      - "8080:8080"
+    environment:
+      REDIS_ADDR: redis:6379
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:


### PR DESCRIPTION
This PR adds a Go + Redis sample demonstrating a simple HTTP service
backed by Redis using Docker Compose.

- / -> shows service running
- /count -> increments counter in Redis

Includes compose.yaml, Dockerfile, and README.
