### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
This PR updates an outdated GitHub Action version.

- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/codeql-analysis.yml`
