### PR TITLE
Add BunkerWeb + MariaDB + Valkey example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ These samples provide a starting point for how to integrate different services u
 
 - [`ASP.NET / MS-SQL`](aspnet-mssql) - Sample ASP.NET core application
 with MS SQL server database.
+- [`BunkerWeb / MariaDB / Valkey`](bunkerweb-mariadb) - Sample setup for BunkerWeb protecting a web application.
 - [`Elasticsearch / Logstash / Kibana`](elasticsearch-logstash-kibana) - Sample Elasticsearch, Logstash, and Kibana stack.
 - [`Go / NGINX / MySQL`](nginx-golang-mysql) - Sample Go application
 with an Nginx proxy and a MySQL database.

--- a/bunkerweb-mariadb/README.md
+++ b/bunkerweb-mariadb/README.md
@@ -1,0 +1,77 @@
+## Compose sample application
+### BunkerWeb protecting a web application with MariaDB and Valkey
+
+Project structure:
+```
+.
+├── compose.yaml
+└── README.md
+```
+
+[_compose.yaml_](compose.yaml)
+```yaml
+services:
+  bunkerweb:
+    image: bunkerity/bunkerweb:1.6.7
+    ...
+  bw-scheduler:
+    image: bunkerity/bunkerweb-scheduler:1.6.7
+    ...
+  bw-ui:
+    image: bunkerity/bunkerweb-ui:1.6.7
+    ...
+  bw-db:
+    image: mariadb:11
+    ...
+  valkey:
+    image: valkey/valkey:9-alpine
+    ...
+  app:
+    image: bunkerity/bunkerweb-hello:v1.0
+    ...
+```
+The compose file defines an application with BunkerWeb services (`bunkerweb`, `bw-scheduler`, `bw-ui`) using `bw-db` (MariaDB) for configuration storage and `valkey` (Valkey) for caching, along with a "Hello World" application (`app`) to be protected.
+
+The setup follows production best practices: specific image versions, database password protection, and health checks.
+
+## Deploy with docker compose
+
+```shell
+$ docker compose up -d
+Creating network "bunkerweb-mariadb_bw-universe" with the default driver
+Creating network "bunkerweb-mariadb_bw-services" with the default driver
+Creating network "bunkerweb-mariadb_bw-db" with the default driver
+Creating Volume "bunkerweb-mariadb_bw-data" with default driver
+Creating Volume "bunkerweb-mariadb_bw-storage" with default driver
+Creating Volume "bunkerweb-mariadb_valkey-data" with default driver
+...
+```
+
+## Expected result
+
+Listing containers must show the BunkerWeb stack and the app running:
+
+```shell
+$ docker compose ps
+NAME                            COMMAND                  SERVICE             STATUS              PORTS
+bunkerweb-mariadb-bunkerweb-1   "/entrypoint.sh …"       bunkerweb           running             0.0.0.0:80->8080/tcp, ...
+bunkerweb-mariadb-bw-ui-1       "/entrypoint.sh …"       bw-ui               running             0.0.0.0:7000->7000/tcp
+...
+```
+
+### Configuration Steps
+
+1.  **Access the Web UI**: Open `http://localhost:7000` (Default: `admin` / `changeme`).
+2.  **Configure protection**:
+    -   Go to **Services** -> **Create**.
+    -   **Server Name**: `localhost`
+    -   **Reverse Proxy URL**: `/`
+    -   **Reverse Proxy Host**: `http://app:80`
+    -   **Apply**.
+
+3.  **Visit Application**: Navigate to `http://localhost` to see the protected app.
+
+Stop and remove the containers
+```shell
+$ docker compose down
+```

--- a/bunkerweb-mariadb/compose.yaml
+++ b/bunkerweb-mariadb/compose.yaml
@@ -1,0 +1,106 @@
+x-bw-env:
+  &bw-env # We use an anchor to avoid repeating the same settings for both services
+  API_WHITELIST_IP: "127.0.0.0/8 10.20.30.0/24" # Make sure to set the correct IP range so the scheduler can send the configuration to the instance
+  # Optional: set an API token and mirror it in both containers
+  API_TOKEN: ""
+
+  DATABASE_URI: "mariadb+pymysql://bunkerweb:changeme@bw-db:3306/db" # Remember to set a stronger password for the database
+services:
+  bunkerweb:
+    # This is the name that will be used to identify the instance in the Scheduler
+    image: bunkerity/bunkerweb:1.6.7
+    ports:
+      - "80:8080/tcp"
+      - "443:8443/tcp"
+      - "443:8443/udp" # For QUIC / HTTP3 support
+    environment:
+      <<: *bw-env # We use the anchor to avoid repeating the same settings for all services
+    restart: "unless-stopped"
+    networks:
+      - bw-universe
+      - bw-services
+
+  bw-scheduler:
+    image: bunkerity/bunkerweb-scheduler:1.6.7
+    environment:
+      <<: *bw-env
+      BUNKERWEB_INSTANCES: "bunkerweb" # Make sure to set the correct instance name
+      SERVER_NAME: ""
+      MULTISITE: "yes"
+      UI_HOST: "http://bw-ui:7000" # Change it if needed
+      USE_REDIS: "yes"
+      REDIS_HOST: "valkey"
+    volumes:
+      - bw-storage:/data # This is used to persist the cache and other data like the backups
+    restart: "unless-stopped"
+    networks:
+      - bw-universe
+      - bw-db
+
+  bw-ui:
+    image: bunkerity/bunkerweb-ui:1.6.7
+    environment:
+      <<: *bw-env
+    restart: "unless-stopped"
+    networks:
+      - bw-universe
+      - bw-db
+
+  bw-db:
+    image: mariadb:11
+    # We set the max allowed packet size to avoid issues with large queries
+    command: --max-allowed-packet=67108864
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_DATABASE: "db"
+      MYSQL_USER: "bunkerweb"
+      MYSQL_PASSWORD: "changeme" # Remember to set a stronger password for the database
+    volumes:
+      - bw-data:/var/lib/mysql
+    restart: "unless-stopped"
+    networks:
+      - bw-db
+
+  valkey: # Valkey service for the persistence of reports/bans/stats
+    image: valkey/valkey:9-alpine
+    command: >
+      valkey-server
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+      --save 60 1000
+      --appendonly yes
+    healthcheck:
+      test: ["CMD-SHELL", "valkey-cli ping | grep PONG"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    sysctls:
+      - net.core.somaxconn=1024
+    volumes:
+      - valkey-data:/data
+    restart: "unless-stopped"
+    networks:
+      - bw-universe
+
+  app:
+    image: bunkerity/bunkerweb-hello:v1.0
+    networks:
+      - bw-services
+    restart: "unless-stopped"
+
+volumes:
+  bw-data:
+  bw-storage:
+  valkey-data:
+
+networks:
+  bw-universe:
+    name: bw-universe
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.20.30.0/24 # Make sure to set the correct IP range so the scheduler can send the configuration to the instance
+  bw-services:
+    name: bw-services
+  bw-db:
+    name: bw-db


### PR DESCRIPTION
This PR adds a new example using **BunkerWeb** to protect a simple web application (`bunkerity/bunkerweb-hello`).

## Description
This example demonstrates a production-ready setup following the official BunkerWeb documentation (Full Stack / Database integration).
It includes:
- **BunkerWeb** (v1.6.7) as the WAF.
- **MariaDB** for configuration and log storage.
- **Valkey** (v8.0) replacing Redis for caching, configured with best practices (persistence, health checks, sysctls).
- **BunkerWeb Scheduler** and **BunkerWeb UI** (port 7000).
- **Hello World App** (`bunkerity/bunkerweb-hello:v1.0`) as the protected service.

## Changes
- Added `bunkerweb-mariadb/` directory with `compose.yaml` and `README.md`.
- Updated root `README.md` to include the new example.

## Verification
- [x] Structure follows the repository conventions.
- [x] `compose.yaml` validates with `docker compose config`.
- [x] Application starts and is accessible via localhost.
