### PR TITLE
fix(react-express-mysql): move --inspect flag before filename in start-watch

### DIFF
--- a/react-express-mysql/backend/package.json
+++ b/react-express-mysql/backend/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "start-watch": "nodemon src/index.js --inspect=0.0.0.0:9229",
+    "start-watch": "nodemon --inspect=0.0.0.0:9229 src/index.js",
     "start-wait-debuger": "nodemon src/index.js --inspect-brk=0.0.0.0:9229",
     "test": "cross-env NODE_ENV=test PORT=8081 mocha --timeout 10000 --exit --inspect=0.0.0.0:9230",
     "test-watch": "nodemon --exec \"npm test\"",


### PR DESCRIPTION
nodemon was passing --inspect=0.0.0.0:9229 as an argument to the script rather than as a Node.js flag, because it appeared after the filename. This prevented the Node.js debugger from listening on port 9229, making the exposed debug ports non-functional.

Moving the flag before the filename ensures nodemon correctly passes it to Node.js, enabling debugger attachment on port 9229 as intended.

Signed-off-by: Bella Le <hello@bella-le.com>