### PR TITLE
nginx-golang-postgres: Update the db service volume mount path

### DIFF
--- a/nginx-golang-postgres/compose.yaml
+++ b/nginx-golang-postgres/compose.yaml
@@ -16,7 +16,7 @@ services:
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password


### PR DESCRIPTION
This PR updates to the latest PostgreSQL Docker images (version 18) volume mount path

- Mount at the higher level directory.  Change the Docker volume configuration to mount at /var/lib/postgresql instead of /var/lib/postgresql/data
- Fixed "dependency db failed to start" error on Container nginx-golang-postgres-db-1