### PR TITLE
fix(prometheus): update alertmanager api_version from v1 to v2

### DIFF
--- a/prometheus-grafana/prometheus/prometheus.yml
+++ b/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
     - targets: []
     scheme: http
     timeout: 10s
-    api_version: v1
+    api_version: v2
 scrape_configs:
 - job_name: prometheus
   honor_timestamps: true


### PR DESCRIPTION
fix: update alertmanager api_version from v1 to v2

APIv1 was deprecated in Alertmanager 0.16.0 and removed in 0.27.0.

https://prometheus.io/docs/alerting/latest/alerts_api/