### PR TITLE
Upgrade aspnet-mssql sample to .NET 8 and remove obsolete MVC compatibility APIs

### DIFF
--- a/aspnet-mssql/app/aspnetapp/Dockerfile
+++ b/aspnet-mssql/app/aspnetapp/Dockerfile
@@ -1,8 +1,8 @@
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 as base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 as base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 COPY . /src
 WORKDIR /src
 RUN ls

--- a/aspnet-mssql/app/aspnetapp/Startup.cs
+++ b/aspnet-mssql/app/aspnetapp/Startup.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -29,8 +28,7 @@ namespace aspnetapp
             });
 
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
-            services.AddControllers();
+            services.AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/aspnet-mssql/app/aspnetapp/aspnetapp.csproj
+++ b/aspnet-mssql/app/aspnetapp/aspnetapp.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- upgrade `aspnet-mssql` target framework from `net5.0` to `net8.0`
- update ASP.NET runtime and SDK Docker base images from `5.0` to `8.0`
- remove obsolete MVC compatibility API usage in `Startup.cs`

## Validation
- `dotnet build aspnet-mssql/app/aspnetapp.sln`
- `dotnet test aspnet-mssql/app/aspnetapp.sln`
- `docker compose -f aspnet-mssql/compose.yaml config`

Co-Authored-By: Oz <oz-agent@warp.dev>
