### PR TITLE
ci(codeql-analysis): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Adds workflow-level `permissions: contents: read`. The analyze job-level `security-events: write` is intentionally untouched (jobs override the workflow-level cap upward where genuinely needed).

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.