### PR TITLE
fixed a dependency conflict

### DIFF
--- a/nginx-flask-mysql/backend/requirements.txt
+++ b/nginx-flask-mysql/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
 mysql-connector==2.2.9
+Werkzeug==2.3.8


### PR DESCRIPTION
This PR fixes a critical crash loop in the nginx-flask-mysql backend container caused by a dependency conflict. The backend fails to start with an ImportError: cannot import name 'url_quote' from 'werkzeug.urls' because it automatically installs the latest version of Werkzeug (3.x), which completely removed the url_quote utility expected by the older version of Flask. Pinning Werkzeug==2.3.8 in backend/requirements.txt restores compatibility, stops the infinite restart loop, and allows the application stack to boot successfully.