### PR TITLE
Add NapCat and qq-ai-bot compose sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ with Spring framework and a Postgres database.
 ## Basic setups for different platforms (not production ready - useful for personal use)
 
 - [`Gitea / PostgreSQL`](gitea-postgres)
+- [`NapCat / qq-ai-bot`](napcat-qq-ai-bot) - Sample messaging-native AI bot stack using NapCat as the OneBot transport and qq-ai-bot as an ACP bridge.
 - [`Nextcloud / PostgreSQL`](nextcloud-postgres)
 - [`Nextcloud / Redis / MariaDB`](nextcloud-redis-mariadb)
 - [`Pi-hole / cloudflared`](pihole-cloudflared-DoH) - Sample Pi-hole setup with use of DoH cloudflared service

--- a/napcat-qq-ai-bot/README.md
+++ b/napcat-qq-ai-bot/README.md
@@ -1,0 +1,120 @@
+## NapCat with qq-ai-bot
+
+This sample shows a **messaging-native AI bot stack** using
+[NapCat](https://github.com/NapNeko/NapCatQQ) as the **OneBot 11** transport and
+[qq-ai-bot](https://github.com/happysnaker/qq-ai-bot) as the **ACP bridge**.
+
+The stack is intentionally aimed at **local validation and tinkering**, not production deployment:
+
+- **NapCat** handles QQ login plus OneBot message transport.
+- **qq-ai-bot** exposes a reverse WebSocket endpoint, keeps per-chat sessions, and forwards prompts and progress through ACP.
+- The sample uses the **built-in mock ACP agent** that ships inside the `qq-ai-bot` image so you can validate the whole path before wiring your own agent runtime.
+
+Project structure:
+
+```text
+.
+├── compose.yaml
+├── napcat.onebot11.reverse-ws.json
+└── README.md
+```
+
+[_compose.yaml_](compose.yaml)
+
+```yaml
+services:
+  qq-ai-bot:
+    image: ghcr.io/happysnaker/qq-ai-bot:latest
+    ports:
+      - "18080:8080"
+    ...
+  napcat:
+    image: mlikiowa/napcat-docker:latest
+    ports:
+      - "3000:3000"
+      - "6099:6099"
+    ...
+```
+
+When you start the sample, Docker Compose creates two services:
+
+- `qq-ai-bot` for the OneBot 11 ↔ ACP bridge
+- `napcat` for QQ login and transport
+
+The sample maps:
+
+- `http://localhost:6099/webui` → NapCat WebUI
+- `http://localhost:18080/readyz` → `qq-ai-bot` readiness endpoint
+- `http://localhost:18080/status` → `qq-ai-bot` status endpoint
+
+> ℹ️ **Info**
+> By default this sample leaves the OneBot token empty on both sides to keep the first run simple.
+> If you want a token, set the same value in both `ONEBOT_ACCESS_TOKEN` inside `compose.yaml`
+> and the `token` field inside `napcat.onebot11.reverse-ws.json`.
+
+## Deploy with Docker Compose
+
+```shell
+docker compose up -d
+```
+
+## Expected result
+
+Check that both containers are running:
+
+```shell
+docker compose ps
+```
+
+You should see two running containers similar to:
+
+```text
+NAME                         IMAGE                                 STATUS
+napcat-qq-ai-bot-napcat-1    mlikiowa/napcat-docker:latest        Up
+napcat-qq-ai-bot-qq-ai-bot-1 ghcr.io/happysnaker/qq-ai-bot:latest Up (healthy)
+```
+
+## Validate the stack
+
+1. Open NapCat WebUI at `http://localhost:6099/webui`
+2. Sign in with the default WebUI token `napcat` (or your `WEBUI_TOKEN` override)
+3. Scan the QQ login QR code in NapCat
+4. Send `/ping` or `/status` to the bot in QQ
+5. Optionally confirm the bridge health endpoints:
+
+   ```shell
+   curl http://localhost:18080/readyz
+   curl http://localhost:18080/status
+   ```
+
+Once the chain is healthy, you have validated a full local path:
+
+```text
+QQ -> NapCat / OneBot 11 -> qq-ai-bot -> mock ACP agent
+```
+
+## Customize the agent side
+
+This sample intentionally starts with the built-in mock ACP agent to keep the first run deterministic.
+
+To swap in your own ACP-compatible agent, edit these environment variables in `compose.yaml`:
+
+- `ACP_AGENT_COMMAND`
+- `ACP_AGENT_ARGS_JSON`
+- `ACP_AGENT_WORKDIR`
+
+You can also tune other bridge settings, such as group mention requirements, progress mode, session storage, and text-length limits, directly in the `qq-ai-bot` service definition.
+
+## Cleanup
+
+Stop the sample:
+
+```shell
+docker compose down
+```
+
+Remove the persistent QQ login state and bot data as well:
+
+```shell
+docker compose down -v
+```

--- a/napcat-qq-ai-bot/compose.yaml
+++ b/napcat-qq-ai-bot/compose.yaml
@@ -1,0 +1,69 @@
+services:
+  qq-ai-bot:
+    image: ghcr.io/happysnaker/qq-ai-bot:latest
+    restart: unless-stopped
+    ports:
+      - "18080:8080"
+    environment:
+      BOT_HOST: 0.0.0.0
+      BOT_PORT: 8080
+      DATA_DIR: /app/data
+      SESSION_STORE: file
+      SESSION_FILE_PATH: /app/data/sessions.json
+      SESSION_TTL_MINUTES: 120
+      REDIS_KEY_PREFIX: qq-ai-bot
+      ONEBOT_MODE: reverse
+      ONEBOT_ACCESS_TOKEN: ""
+      ONEBOT_REVERSE_WS_HOST: 0.0.0.0
+      ONEBOT_REVERSE_WS_PORT: 16700
+      ONEBOT_REVERSE_WS_PATH: /onebot/v11/ws
+      ONEBOT_ALLOW_GROUP: "true"
+      ONEBOT_REQUIRE_MENTION_IN_GROUP: "true"
+      ONEBOT_ALLOW_PRIVATE: "true"
+      ONEBOT_ALLOW_GROUP_COMMANDS_WITHOUT_MENTION: "false"
+      ONEBOT_GROUP_CONFIG_FILE: /app/examples/group-rules.example.json
+      ONEBOT_PROGRESS_MODE: message
+      ONEBOT_OUTBOUND_MAX_TEXT_LENGTH: 1400
+      ACP_AGENT_COMMAND: node
+      ACP_AGENT_ARGS_JSON: '["dist/examples/mock-acp-agent.js"]'
+      ACP_AGENT_WORKDIR: /app
+      ACP_CLIENT_NAME: qq-ai-bot
+      ACP_REUSE_SESSION: "true"
+      ACP_VERBOSE_MODE: verbose
+      ACP_PERMISSION_STRATEGY: allow_once
+      ACP_PROGRESS_THROTTLE_MS: 800
+      ACP_MAX_PROGRESS_UPDATES: 6
+      ACP_MAX_INBOUND_IMAGES: 3
+      ACP_MAX_INBOUND_IMAGE_BYTES: 6291456
+    volumes:
+      - qq_ai_bot_data:/app/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q -O - http://127.0.0.1:8080/readyz >/dev/null 2>&1 || exit 1",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  napcat:
+    image: mlikiowa/napcat-docker:latest
+    restart: unless-stopped
+    depends_on:
+      qq-ai-bot:
+        condition: service_healthy
+    environment:
+      NAPCAT_UID: ${NAPCAT_UID:-1000}
+      NAPCAT_GID: ${NAPCAT_GID:-1000}
+      WEBUI_TOKEN: ${WEBUI_TOKEN:-napcat}
+    ports:
+      - "3000:3000"
+      - "6099:6099"
+    volumes:
+      - ./napcat.onebot11.reverse-ws.json:/app/napcat/config/onebot11.json:ro
+      - napcat_qq:/app/.config/QQ
+
+volumes:
+  napcat_qq:
+  qq_ai_bot_data:

--- a/napcat-qq-ai-bot/napcat.onebot11.reverse-ws.json
+++ b/napcat-qq-ai-bot/napcat.onebot11.reverse-ws.json
@@ -1,0 +1,25 @@
+{
+  "network": {
+    "httpServers": [],
+    "httpSseServers": [],
+    "httpClients": [],
+    "websocketServers": [],
+    "websocketClients": [
+      {
+        "enable": true,
+        "name": "qq-ai-bot-reverse-ws",
+        "url": "ws://qq-ai-bot:16700/onebot/v11/ws",
+        "reportSelfMessage": false,
+        "messagePostFormat": "array",
+        "token": "",
+        "debug": false,
+        "heartInterval": 30000,
+        "reconnectInterval": 30000
+      }
+    ],
+    "plugins": []
+  },
+  "musicSignUrl": "",
+  "enableLocalFile2Url": false,
+  "parseMultMsg": false
+}


### PR DESCRIPTION
## Summary
- add a new `napcat-qq-ai-bot` Docker Compose sample under the "basic setups" section
- show a messaging-native local stack using NapCat for QQ / OneBot transport and qq-ai-bot as the ACP bridge
- keep the sample intentionally local-development oriented with the built-in mock ACP agent for deterministic first-run validation

## Why this sample is useful
Most Compose examples around AI focus on web UIs, model serving, or generic chat apps. This sample demonstrates a different but real integration shape:

```text
QQ -> NapCat / OneBot 11 -> qq-ai-bot -> ACP-compatible agent
```

That gives Compose users one concrete reference for a message-channel deployment path, not only browser-facing apps.

## What is included
- `compose.yaml` for `napcat` + `qq-ai-bot`
- a matching NapCat OneBot reverse-WS config file
- a README that documents the local-validation flow, ports, login path, token note, health endpoints, and how to replace the mock ACP agent with a real one

Project page: https://happysnaker.github.io/qq-ai-bot/

## Notes
- this stays aligned with the repository's local / tinkering scope and is explicitly not framed as production-ready
- the sample uses the published `ghcr.io/happysnaker/qq-ai-bot:latest` image
- I validated the Compose file shape with `docker compose config`

Closes #780
