### PR TITLE
Update Postgres image and restart policy in compose.yaml

### DIFF
--- a/gitea-postgres/compose.yaml
+++ b/gitea-postgres/compose.yaml
@@ -7,18 +7,18 @@ services:
       - DB_NAME=gitea
       - DB_USER=gitea
       - DB_PASSWD=gitea
-    restart: always
+    restart: unless-stopped
     volumes:
       - git_data:/data
     ports:
       - 3000:3000
   db:
-    image: postgres:alpine
+    image: postgres:17-alpine
     environment:
       - POSTGRES_USER=gitea
       - POSTGRES_PASSWORD=gitea
       - POSTGRES_DB=gitea
-    restart: always
+    restart: unless-stopped
     volumes:
       - db_data:/var/lib/postgresql/data
     expose:


### PR DESCRIPTION
Edited version of postgres image in gitea-postgres - encountered db startup failures with postgres version 18+. Also changed restart policy for both services in gitea-postgres to unless-stopped, to enable easier stopping