### PR TITLE
docs: fix typos and grammar in sample README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with an Nginx proxy and a MySQL database.
 application with an Nginx proxy and a PostgreSQL database.
 - [`Java Spark / MySQL`](sparkjava-mysql) - Sample Java application and
 a MySQL database.
-- [`NGINX / ASP.NET / MySQL`](nginx-aspnet-mysql) - Sample Nginx reverse proxy with an C# backend using ASP.NET.
+- [`NGINX / ASP.NET / MySQL`](nginx-aspnet-mysql) - Sample Nginx reverse proxy with a C# backend using ASP.NET.
 - [`NGINX / Flask / MongoDB`](nginx-flask-mongo) - Sample Python/Flask
 application with Nginx proxy and a Mongo database.
 - [`NGINX / Flask / MySQL`](nginx-flask-mysql) - Sample Python/Flask application with an Nginx proxy and a MySQL database.

--- a/official-documentation-samples/wordpress/README.md
+++ b/official-documentation-samples/wordpress/README.md
@@ -69,7 +69,7 @@ Compose to set up and run WordPress. Before starting, make sure you have
 
    > **Notes**:
    >
-   * The docker volumes `db_data` and `wordpress_data` persists updates made by WordPress
+   * The docker volumes `db_data` and `wordpress_data` persist updates made by WordPress
    to the database, as well as the installed themes and plugins. [Learn more about docker volumes](https://docs.docker.com/storage/volumes/)
    >
    * WordPress Multisite works only on ports `80` and `443`.

--- a/pihole-cloudflared-DoH/README.md
+++ b/pihole-cloudflared-DoH/README.md
@@ -104,5 +104,5 @@ $ docker compose down -v
 ### - Installing on Ubuntu may conflict with `systemd-resolved` - see [Installing on Ubuntu](https://github.com/pi-hole/docker-pi-hole#installing-on-ubuntu-or-fedora) for help.
 
 ### - Environment variables are version-dependent
-  Environment variables like "CONDIIONAL_FORWARDING*" and "DNS1" are deprecated and replaced by e.g. "REV_SERVER*" and "PIHOLE_DNS" in version 5.8+.
+  Environment variables like "CONDITIONAL_FORWARDING*" and "DNS1" are deprecated and replaced by e.g. "REV_SERVER*" and "PIHOLE_DNS" in version 5.8+.
   Current information about environment variables can be found here: https://github.com/pi-hole/docker-pi-hole

--- a/react-express-mongodb/README.md
+++ b/react-express-mongodb/README.md
@@ -43,7 +43,7 @@ services:
 ```
 The compose file defines an application with three services `frontend`, `backend` and `db`.
 When deploying the application, docker compose maps port 3000 of the frontend service container to port 3000 of the host as specified in the file.
-Make sure port 3000 on the host is not already being in use.
+Make sure port 3000 on the host is not already in use.
 
 ## Deploy with docker compose
 
@@ -97,7 +97,7 @@ The first line defines the version of a file. It sounds confusing :confused:. Wh
 
 __Services__
 
-Our main goal to create a containers, it starts from here. As you can see there are three services(Docker images): 
+Our main goal is to create containers, it starts from here. As you can see there are three services(Docker images): 
 - First is __frontend__ 
 - Second is __server__ which is __backend - Express(NodeJS)__. I used a name server here, it's totally on you to name it __backend__.
 - Third is __mongo__ which is db __MongoDB__.
@@ -110,7 +110,7 @@ __Explanation of service server__
 
 - Defining a **nodejs** service as __server__.
 - We named our **node server** container service as **server**. Assigning a name to the containers makes it easier to read when there are lot of containers on a machine, it can also avoid randomly generated container names. (Although in this case, __container_name__ is also __server__, this is merely personal preference, the name of the service and container do not have to be the same.) 
-- Docker container starts automatically if its fails.
+- Docker container starts automatically if it fails.
 - Building the __server__ image using the Dockerfile from the current directory and passing an argument to the
 backend(server) `DockerFile`.
 - Mapping the host port to the container port.
@@ -122,7 +122,7 @@ We add another service called **mongo** but this time instead of building it fro
 __Explanation of service mongo__
 
 - Defining a **mongodb** service as __mongo__.
-- Pulling the mongo 4.2.0 image image again from [DockerHub](https://hub.docker.com/).
+- Pulling the mongo 4.2.0 image again from [DockerHub](https://hub.docker.com/).
 - Mount our current db directory to container. 
 - For persistent storage, we mount the host directory ( just like I did it in **Node** image inside `DockerFile` to reflect the changes) `/data` ( you need to create a directory in root of your project in order to save changes to locally as well) to the container directory `/data/db`, which was identified as a potential mount point in the `mongo Dockerfile` we saw earlier.
 - Mounting volumes gives us persistent storage so when starting a new container, Docker Compose will use the volume of any previous containers and copy it to the new container, ensuring that no data is lost.
@@ -131,4 +131,4 @@ __Explanation of service mongo__
 
 :key: `If you wish to check your DB changes on your local machine as well. You should have installed MongoDB locally, otherwise you can't access your mongodb service of container from host machine.` 
 
-:white_check_mark: You should check your __mongo__ version is same as used in image. You can see the version of __mongo__ image in `docker-compose `file, I used __image: mongo:4.2.0__. If your mongo db version on your machine is not same then furst you have to updated your  local __mongo__ version in order to works correctly.
+:white_check_mark: You should check your __mongo__ version is same as used in image. You can see the version of __mongo__ image in `docker-compose `file, I used __image: mongo:4.2.0__. If your mongo db version on your machine is not same then first you have to update your  local __mongo__ version in order to work correctly.

--- a/wasmedge-kafka-mysql/README.md
+++ b/wasmedge-kafka-mysql/README.md
@@ -66,7 +66,7 @@ services:
       MYSQL_ROOT_PASSWORD: whalehello
 ```
 
-The compose file defines an application with three services `redpanda`, `etl` and `db`. The `redpanda` service is a Kafka-compatible messaging server that produces messages in a queue topic. The `etl` service, in the WasmEdge container that subscribes to the queue topic and receives incoming messages. Each incoming message is parsed and stored in the `db` MySQL (MariaDB) database server.
+The compose file defines an application with three services `redpanda`, `etl` and `db`. The `redpanda` service is a Kafka-compatible messaging server that produces messages in a queue topic. The `etl` service is in the WasmEdge container that subscribes to the queue topic and receives incoming messages. Each incoming message is parsed and stored in the `db` MySQL (MariaDB) database server.
 
 ## Deploy with docker compose
 

--- a/wasmedge-mysql-nginx/README.md
+++ b/wasmedge-mysql-nginx/README.md
@@ -2,7 +2,7 @@
 
 ![Compatible with Docker+Wasm](../icon_wasm.svg)
 
-This sample demonstrates a web application with a WebAssembly (Wasm) microservice, written in Rust. The Wasm microservice is an HTTP API connected to a MySQL (MariaDB) database. The API is invoked via from JavaScript in a web interface serving static HTML. The microservice is compiled into WebAssembly (Wasm) and runs in the WasmEdge Runtime, a secure and lightweight alternative to natively compiled Rust apps in Linux containers. Checkout [this article](https://blog.logrocket.com/rust-microservices-server-side-webassembly/) or [this video](https://www.youtube.com/watch?v=VSqMPFr7SEs) to learn how the Rust code in this microservice works.
+This sample demonstrates a web application with a WebAssembly (Wasm) microservice, written in Rust. The Wasm microservice is an HTTP API connected to a MySQL (MariaDB) database. The API is invoked from JavaScript in a web interface serving static HTML. The microservice is compiled into WebAssembly (Wasm) and runs in the WasmEdge Runtime, a secure and lightweight alternative to natively compiled Rust apps in Linux containers. Checkout [this article](https://blog.logrocket.com/rust-microservices-server-side-webassembly/) or [this video](https://www.youtube.com/watch?v=VSqMPFr7SEs) to learn how the Rust code in this microservice works.
 
 ## WasmEdge server with Nginx proxy and MySQL database
 
@@ -98,13 +98,13 @@ To insert multiple records, use the `/create_orders` endpoint and POST a JSON ar
 curl http://localhost:8080/create_orders -X POST -d @db/orders.json
 ```
 
-When the WasmEdge web service receives a GET request to the `/orders` endpoint, it gets all rows from the `orders` table and return the result set in a JSON array in the HTTP response.
+When the WasmEdge web service receives a GET request to the `/orders` endpoint, it gets all rows from the `orders` table and returns the result set in a JSON array in the HTTP response.
 
 ```bash
 curl http://localhost:8080/orders
 ```
 
-When the WasmEdge web service receives a POST request to the `/update_order` endpoint, it extracts the JSON data from the POST body and update the `Order` record in the database table that matches the `order_id` in the input data.
+When the WasmEdge web service receives a POST request to the `/update_order` endpoint, it extracts the JSON data from the POST body and updates the `Order` record in the database table that matches the `order_id` in the input data.
 
 ```bash
 curl http://localhost:8080/update_order -X POST -d @db/update_order.json


### PR DESCRIPTION
## Summary

Fix 15 spelling and grammar typos across the sample READMEs and the repository
index. Documentation only -- no compose files, Dockerfiles or sample code were
touched.

### Findings from the report

**`README.md`**
- `Sample Nginx reverse proxy with an C# backend` -> `with a C# backend`

**`react-express-mongodb/README.md`**
- `port 3000 on the host is not already being in use` -> `is not already in use`
- `Our main goal to create a containers, it starts from here.` ->
  `Our main goal is to create containers, it starts from here.`
- `starts automatically if its fails` -> `if it fails`
- `Pulling the mongo 4.2.0 image image again` -> `image again`
- `then furst you have to updated your local mongo version in order to works
  correctly` -> `then first you have to update ... in order to work correctly`

**`official-documentation-samples/wordpress/README.md`**
- ``The docker volumes `db_data` and `wordpress_data` persists updates`` ->
  `persist updates` (plural subject)

**`wasmedge-mysql-nginx/README.md`**
- `The API is invoked via from JavaScript` -> `is invoked from JavaScript`
- ``it gets all rows from the `orders` table and return the result set`` -> `returns`
- ``it extracts the JSON data from the POST body and update the `Order` record`` -> `updates`

**`pihole-cloudflared-DoH/README.md`**
- `"CONDIIONAL_FORWARDING*"` -> `"CONDITIONAL_FORWARDING*"` (spelled correctly
  earlier in the same file)

**`wasmedge-kafka-mysql/README.md`**
- ``The `etl` service, in the WasmEdge container that subscribes ...`` ->
  ``The `etl` service is in the WasmEdge container that subscribes ...``
  (the original sentence has no main verb)

### Deliberately left alone

- **`react-express-mysql/backend/README.md`** -- nine further typos were reported
  in this file, but it is a vendored copy of
  [BretFisher/node-docker-good-defaults](https://github.com/BretFisher/node-docker-good-defaults)
  and the directory carries its own `LICENSE` (MIT, (c) Bret Fisher). Edits here
  would diverge from upstream and cannot be sent back there, so I left it
  untouched. Happy to include it if you would prefer.
- `The docker volumes ...` -- a lowercase/uppercase `Docker` change was
  suggested; the file uses lowercase `docker` consistently in that note, so I
  treated it as house style.
- `CONTRIBUTING.md` -- a suggestion to drop the comma in `for the application,
  technology, language, or framework` was a false positive; the comma is correct.

### One thing I did not change but you may want to

In `official-documentation-samples/wordpress/README.md` the note refers to a
volume named `wordpress_data`, but the compose snippet immediately above defines
`wp_data`. That looked like a content fix rather than a typo, so I left it for a
maintainer to confirm. The same text also appears in the official docs.

No functional changes -- documentation only. Commits are signed off per the DCO.